### PR TITLE
Feat: 순위 데이터 반영기간 자동 표기기능 추가 | Fix: 리뷰카드 slide 시, 구독 페이지 숫자가 변하는 문제 수정. 추천페이지 2번 이상 진입 시, 웹툰 카드 클릭 문제 수정

### DIFF
--- a/src/pages/Main.js
+++ b/src/pages/Main.js
@@ -19,7 +19,7 @@ import { Button, Text, Image } from "../elements";
 import { Color } from "../shared/common";
 import BannerImg1 from "../images/banner1.jpg";
 import BannerImg2 from "../images/banner2.jpg";
-import BannerImg3 from "../images/banner3.png";
+// import BannerImg3 from "../images/banner3.png";
 
 const Main = () => {
   const dispatch = useDispatch();
@@ -39,6 +39,7 @@ const Main = () => {
 
   // states
   const [is_best, setIsBest] = React.useState(true);
+  const [updatePeriod, setUpdatePeriod] = React.useState("");
 
   // selectors
   const toon_list = useSelector((state) => state.webtoon.toon_list);
@@ -91,6 +92,11 @@ const Main = () => {
 
   React.useEffect(() => {
     dispatch(reviewerActions.getBestReviewer());
+    setUpdatePeriod(
+      `${new Date(
+        parseInt(new Date().getTime() - 604800000)
+      ).toLocaleDateString()} ~ ${new Date().toLocaleDateString()}`
+    );
   }, []);
 
   React.useEffect(() => {
@@ -161,7 +167,7 @@ const Main = () => {
             금주의 웹투니버스 순위
           </Text>
           <ToolTip position="top-center" align={true}>
-            2021.08.23 ~ 2021.08.29 기준
+            {`${updatePeriod} 기준`}
           </ToolTip>
         </TooltipGrid>
         <Button

--- a/src/pages/Recommendation.js
+++ b/src/pages/Recommendation.js
@@ -55,8 +55,10 @@ const Recommendation = () => {
   const similar_user_list = toon_list.filter((toon) =>
     toon.filterConditions.includes("similarUserOffer")
   );
-  const for_user_list = toon_list.filter((toon) =>
-    toon.filterConditions.includes("forUser")
+  const [for_user_list, set_for_user_list] = React.useState(
+    toon_list.filter((toon) =>
+      toon.filterConditions.includes("similarUserOffer")
+    )
   );
 
   const md_review = [
@@ -104,11 +106,11 @@ const Recommendation = () => {
 
   const handleBeforeChange = React.useCallback(() => {
     setDragging(true);
-  }, [setDragging]);
+  }, []);
 
   const handleAfterChange = React.useCallback(() => {
     setDragging(false);
-  }, [setDragging]);
+  }, []);
 
   const handleOnItemClick = React.useCallback(
     (e) => {
@@ -120,15 +122,21 @@ const Recommendation = () => {
   // effects
   React.useEffect(() => {
     if (!end_toon_list.length || !md_offer_list.length || !best_reviewer_list) {
-      dispatch(webtoonActions.getOfferWebtoonListForLogin());
+      dispatch(webtoonActions.getOfferWebtoonList());
     }
   }, []);
 
   React.useEffect(() => {
     if (is_login) {
-      dispatch(webtoonActions.getForUserWebtoonList());
+      dispatch(webtoonActions.getWebtoonListForLogin());
     }
   }, [is_login]);
+
+  React.useEffect(() => {
+    set_for_user_list(
+      toon_list.filter((toon) => toon.filterConditions.includes("forUser"))
+    );
+  }, [toon_list]);
 
   const is_loading = useSelector((state) => state.webtoon.is_loading);
 

--- a/src/pages/User.js
+++ b/src/pages/User.js
@@ -58,13 +58,9 @@ const User = (props) => {
     setDragging(true);
   }, [setDragging]);
 
-  const handleAfterChange = React.useCallback(
-    (currentSlide) => {
-      setDragging(false);
-      setCurSubscribePage(currentSlide + 1);
-    },
-    [setDragging]
-  );
+  const handleAfterChange = React.useCallback(() => {
+    setDragging(false);
+  }, [setDragging]);
 
   const handleOnItemClick = React.useCallback(
     (e) => {
@@ -72,6 +68,8 @@ const User = (props) => {
     },
     [dragging]
   );
+
+  console.log(dragging);
 
   const [windowSize, setWindowSize] = useState(window.innerWidth);
   const handleWindowResize = React.useCallback((event) => {
@@ -396,7 +394,10 @@ const User = (props) => {
           {subscribeList.length ? (
             <Slick
               is_variableWidth={false}
-              _afterChange={handleAfterChange}
+              _afterChange={(currentSlide) => {
+                handleAfterChange();
+                setCurSubscribePage(currentSlide + 1);
+              }}
               _beforeChange={handleBeforeChange}
             >
               {subscribeList.map((list, idx) => (

--- a/src/redux/modules/webtoon.js
+++ b/src/redux/modules/webtoon.js
@@ -13,7 +13,8 @@ const ADD_TOON_ONE_INFO = "webtoon/ADD_TOON_ONE_INFO";
 const SET_TOON_AVG_POINT = "webtoon/SET_TOON_AVG_POINT";
 const START_LOADING = "webtoon/START_LOADING";
 const END_LOADING = "webtoon/END_LOADING";
-const REMOVE_TOONS_FOR_USER = "webtoon/REMOVE_TOONS_FOR_USER";
+const REMOVE_FOR_USER_FILTER_CONDITION =
+  "webtoon/REMOVE_FOR_USER_FILTER_CONDITION";
 const SET_CALLED_FOR_USER = "webtoon/SET_CALLED_FOR_USER";
 
 ///////////////////////////////////////////////////////////
@@ -42,7 +43,10 @@ const setToonAvgPoint = createAction(
 );
 const startLoading = createAction(START_LOADING, () => ({}));
 const endLoading = createAction(END_LOADING, () => ({}));
-const removeToonsForUser = createAction(REMOVE_TOONS_FOR_USER, () => ({}));
+const removeForUserFilterCondition = createAction(
+  REMOVE_FOR_USER_FILTER_CONDITION,
+  () => ({})
+);
 const setCalledForUser = createAction(SET_CALLED_FOR_USER, () => ({}));
 
 ///////////////////////////////////////////////////////////
@@ -80,7 +84,7 @@ const getRankWebtoonList = () => async (dispatch, getState) => {
 };
 
 // 비슷한 취향의 유저가 본, ~님을 위한 추천 불러오기
-const getForUserWebtoonList = () => async (dispatch, getState) => {
+const getWebtoonListForLogin = () => async (dispatch, getState) => {
   try {
     const isCalledForUser = getState().webtoon.is_called_for_user;
     let { data: forUserToons } = await offerAPI.getForUser();
@@ -89,7 +93,7 @@ const getForUserWebtoonList = () => async (dispatch, getState) => {
       return toon;
     });
     if (isCalledForUser) {
-      dispatch(removeToonsForUser());
+      dispatch(removeForUserFilterCondition());
     }
     dispatch(addToonList(forUserToons, "forUser"));
     if (!isCalledForUser) {
@@ -110,7 +114,7 @@ const getForUserWebtoonList = () => async (dispatch, getState) => {
 };
 
 // 추천 웹툰 리스트 받아오기 (완결작, MD, 베스트 리뷰어의 추천)
-const getOfferWebtoonListForLogin = () => {
+const getOfferWebtoonList = () => {
   return async function (dispatch, getState, { history }) {
     try {
       const { data: endOfferToons } = await offerAPI.getEnd();
@@ -382,16 +386,16 @@ export default handleActions(
       produce(state, (draft) => {
         draft.is_loading = false;
       }),
-    [REMOVE_TOONS_FOR_USER]: (state, action) =>
+    [REMOVE_FOR_USER_FILTER_CONDITION]: (state, action) =>
       produce(state, (draft) => {
-        draft.toon_list = draft.toon_list.map((toon) => {
-          const forUserIdx = toon.filterConditions.findIndex(
-            (fc) => fc === "forUser"
+        const filtered = draft.toon_list.filter((toon) =>
+          toon.filterConditions.includes("forUser")
+        );
+        filtered.map((toon) => {
+          toon.filterConditions.splice(
+            toon.filterConditions.indexOf("forUser"),
+            1
           );
-          if (forUserIdx !== -1) {
-            toon.filterConditions.splice(forUserIdx, 1);
-          }
-          return toon;
         });
       }),
     [SET_CALLED_FOR_USER]: (state, action) =>
@@ -404,8 +408,8 @@ export default handleActions(
 
 const actionCreators = {
   getRankWebtoonList,
-  getForUserWebtoonList,
-  getOfferWebtoonListForLogin,
+  getWebtoonListForLogin,
+  getOfferWebtoonList,
   getToonOneServer,
   addToonList,
   setToonAvgPoint,


### PR DESCRIPTION
* 추천 페이지에 route될 때마다 ForUser API를 호출하도록 수정했었는데, 이 때문에 slick의 handleBeforeChange가 호출되었음.
* 정확한 원인은 파악하기 어려웠으나, filterConditions에 새로운 forUser를 부여하기 위해 기존의 forUser를 삭제하는 과정이 주석처리하자, 정상적으로 동작함.
* forUser 리스트는 toon_list를 filter해서 가져오고, 해당 리스트는 state로 관리되지 않았기 때문에, 모든 렌더링마다 filter하는 과정이 수반됨.
* 이에 렌더링 중 갑작스런 리스트 목록의 변화로 인한 오류라고 가정함.
* 리스트 변화에 안정성을 주기 위해, 해당 리스트를 state로 변경. useEffect로 setState하게끔 조치함으로서 문제 해결.